### PR TITLE
refactor: align Triton block_info clamping with CUTE backend

### DIFF
--- a/flash_sparse_attn/ops/triton/block_info.py
+++ b/flash_sparse_attn/ops/triton/block_info.py
@@ -102,6 +102,16 @@ def get_n_block_min_max(
             n_block_max = tl.minimum(n_block_min_new + n_block_count, n_block_max)
             n_block_min = n_block_min_new
             n_block_sink_max = tl.where(split_idx == 0, n_block_sink_max, 0)
+    n_block_min = tl.minimum(n_block_min, n_block_max)
+    if IS_LOCAL:
+        n_block_window_max = tl.maximum(
+            tl.minimum(n_block_window_max, n_block_min),
+            n_block_window_min,
+        )
+        n_block_sink_max = tl.maximum(n_block_sink_max, n_block_sink_min)
+    else:
+        n_block_window_min = 0
+        n_block_window_max = 0
     return (
         n_block_min,
         n_block_max,
@@ -195,6 +205,16 @@ def get_m_block_min_max(
             m_block_count = tl.where(split_idx < extra, base + 1, base)
             m_block_max = tl.minimum(m_block_min_new + m_block_count, m_block_max)
             m_block_min = m_block_min_new
+    m_block_min = tl.minimum(m_block_min, m_block_max)
+    if IS_LOCAL:
+        m_block_window_min = tl.minimum(
+            tl.maximum(m_block_window_min, m_block_max),
+            m_block_window_max,
+        )
+        m_block_sink_min = tl.minimum(m_block_sink_min, m_block_sink_max)
+    else:
+        m_block_window_min = 0
+        m_block_window_max = 0
     return (
         m_block_min,
         m_block_max,

--- a/flash_sparse_attn/ops/triton/scheduler.py
+++ b/flash_sparse_attn/ops/triton/scheduler.py
@@ -895,7 +895,6 @@ class AttnFwdBlockScheduler:
                 )
             else:
                 n_block_max_no_mask = n_block_min
-            n_block_window_max = tl.minimum(n_block_window_max, n_block_max_no_mask)
             n_block_window_max_no_mask = block_info.get_n_block_min_causal_local_mask(
                 seqlen_q=config.actual_seqlen_q,
                 seqlen_k=config.actual_seqlen_k,
@@ -921,20 +920,15 @@ class AttnFwdBlockScheduler:
                 IS_LOCAL=True,
                 QHEAD_PER_KVHEAD_PACKGQA=config.QHEAD_PER_KVHEAD_PACKGQA,
             )
-            n_block_window_min_no_mask = tl.minimum(
-                n_block_window_min_no_mask, n_block_window_max_no_mask
-            )
-
             # Clamp window no-mask boundaries to the window's range
-            if IS_SPLIT_KV:
-                n_block_window_max_no_mask = tl.maximum(
-                    tl.minimum(n_block_window_max_no_mask, n_block_window_max),
-                    n_block_window_min,
-                )
-                n_block_window_min_no_mask = tl.maximum(
-                    tl.minimum(n_block_window_min_no_mask, n_block_window_max),
-                    n_block_window_min,
-                )
+            n_block_window_max_no_mask = tl.maximum(
+                tl.minimum(n_block_window_max_no_mask, n_block_window_max),
+                n_block_window_min,
+            )
+            n_block_window_min_no_mask = tl.maximum(
+                tl.minimum(n_block_window_min_no_mask, n_block_window_max_no_mask),
+                n_block_window_min,
+            )
         else:
             n_block_window_min = 0
             n_block_window_max = 0
@@ -1051,7 +1045,6 @@ class AttnBwdBlockScheduler:
         if IS_LOCAL:
             # Compute local m_block range for this n_block
             m_block_min_no_mask = m_block_max
-            m_block_window_min = tl.maximum(m_block_window_min, m_block_min_no_mask)
             m_block_window_min_no_mask = block_info.get_m_block_min_causal_local_mask(
                 seqlen_q=config.actual_seqlen_q,
                 seqlen_k=config.actual_seqlen_k,
@@ -1079,6 +1072,7 @@ class AttnBwdBlockScheduler:
                 TILE_M=config.TILE_M,
                 IS_LOCAL=True,
             )
+            # Clamp window no-mask boundaries to the window's range
             m_block_window_max_no_mask = tl.maximum(
                 m_block_window_max_no_mask, m_block_window_min_no_mask
             )
@@ -1228,7 +1222,6 @@ class AttnDecBlockScheduler:
                 n_block_min,
                 n_block_max_no_mask,
             )
-            n_block_window_max = tl.minimum(n_block_window_max, n_block_max_no_mask)
             n_block_window_max_no_mask = block_info.get_n_block_min_causal_local_mask(
                 seqlen_q=1,
                 seqlen_k=config.actual_seqlen_k,
@@ -1254,17 +1247,13 @@ class AttnDecBlockScheduler:
                 IS_LOCAL=True,
                 QHEAD_PER_KVHEAD_PACKGQA=config.QHEAD_PER_KVHEAD_PACKGQA,
             )
-            n_block_window_min_no_mask = tl.minimum(
-                n_block_window_min_no_mask, n_block_window_max_no_mask
-            )
-
             # Clamp window no-mask boundaries to the window's range
             n_block_window_max_no_mask = tl.maximum(
                 tl.minimum(n_block_window_max_no_mask, n_block_window_max),
                 n_block_window_min,
             )
             n_block_window_min_no_mask = tl.maximum(
-                tl.minimum(n_block_window_min_no_mask, n_block_window_max),
+                tl.minimum(n_block_window_min_no_mask, n_block_window_max_no_mask),
                 n_block_window_min,
             )
         elif not IS_GATHER_KV:


### PR DESCRIPTION
## Summary

Align Triton block_info interval clamping with the CUTE backend optimization, eliminating redundant boundary calculations in schedulers.

## Changes

### block_info.py
- Add post-computation clamping to `get_n_block_min_max` and `get_m_block_min_max` ensuring returned intervals are strictly non-overlapping: `[sink_min, sink_max) | [window_min, window_max) | [block_min, block_max)`

### scheduler.py
- Remove redundant `tl.minimum/tl.maximum` operations in fwd/bwd/dec schedulers that are now guaranteed by block_info clamping
- Remove IS_SPLIT_KV conditional clamp branch in fwd scheduler (unified clamp covers both paths)
- Simplify no-mask boundary calculations

## Why this is correct
The clamping in block_info guarantees:
- `n_block_window_max <= n_block_min` (fwd/dec)
- `m_block_window_min >= m_block_max` (bwd)

So the removed `min/max` operations were identity transforms (input == output).

## Performance
- ~5-7 fewer scalar ALU instructions per scheduler create
- Eliminates one compile-time branch specialization
- Most impactful on decode path where scheduler prologue is a larger fraction of kernel time